### PR TITLE
[1.2.0] Upgrade to Alpine 3.8

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -21,12 +21,12 @@ RUN \
     #  - Temporarily install perl-digest-hmac to provide shasum tools
     #  - Download composer-setup.php & check for file integrity
     #  - Run composer installation script
-    #  - Cleanup: remove installation script & perl-digest-hmac binaries
-    apk add --no-cache --virtual build-deps perl-digest-hmac && \
+    #  - Cleanup: remove installation script & core-utils binaries
+    apk add --no-cache --virtual build-deps coreutils && \
     curl https://getcomposer.org/installer -o composer-setup.php; \
-    ACTUAL_SIG=`shasum -a 384 composer-setup.php | awk '{ printf "%s",$1; }'`; \
+    ACTUAL_SIG=`sha384sum composer-setup.php | awk '{ printf "%s",$1; }'`; \
     EXPECTED_SIG=`curl -s https://composer.github.io/installer.sig | tr -d "\n"`; \
-    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] && \
+    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     apk del build-deps; \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -21,12 +21,12 @@ RUN \
     #  - Temporarily install perl-digest-hmac to provide shasum tools
     #  - Download composer-setup.php & check for file integrity
     #  - Run composer installation script
-    #  - Cleanup: remove installation script & perl-digest-hmac binaries
-    apk add --no-cache --virtual build-deps perl-digest-hmac && \
+    #  - Cleanup: remove installation script & core-utils binaries
+    apk add --no-cache --virtual build-deps coreutils && \
     curl https://getcomposer.org/installer -o composer-setup.php; \
-    ACTUAL_SIG=`shasum -a 384 composer-setup.php | awk '{ printf "%s",$1; }'`; \
+    ACTUAL_SIG=`sha384sum composer-setup.php | awk '{ printf "%s",$1; }'`; \
     EXPECTED_SIG=`curl -s https://composer.github.io/installer.sig | tr -d "\n"`; \
-    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] && \
+    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     apk del build-deps; \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -21,12 +21,12 @@ RUN \
     #  - Temporarily install perl-digest-hmac to provide shasum tools
     #  - Download composer-setup.php & check for file integrity
     #  - Run composer installation script
-    #  - Cleanup: remove installation script & perl-digest-hmac binaries
-    apk add --no-cache --virtual build-deps perl-digest-hmac && \
+    #  - Cleanup: remove installation script & core-utils binaries
+    apk add --no-cache --virtual build-deps coreutils && \
     curl https://getcomposer.org/installer -o composer-setup.php; \
-    ACTUAL_SIG=`shasum -a 384 composer-setup.php | awk '{ printf "%s",$1; }'`; \
+    ACTUAL_SIG=`sha384sum composer-setup.php | awk '{ printf "%s",$1; }'`; \
     EXPECTED_SIG=`curl -s https://composer.github.io/installer.sig | tr -d "\n"`; \
-    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] && \
+    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     apk del build-deps; \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -21,12 +21,12 @@ RUN \
     #  - Temporarily install perl-digest-hmac to provide shasum tools
     #  - Download composer-setup.php & check for file integrity
     #  - Run composer installation script
-    #  - Cleanup: remove installation script & perl-digest-hmac binaries
-    apk add --no-cache --virtual build-deps perl-digest-hmac && \
+    #  - Cleanup: remove installation script & core-utils binaries
+    apk add --no-cache --virtual build-deps coreutils && \
     curl https://getcomposer.org/installer -o composer-setup.php; \
-    ACTUAL_SIG=`shasum -a 384 composer-setup.php | awk '{ printf "%s",$1; }'`; \
+    ACTUAL_SIG=`sha384sum composer-setup.php | awk '{ printf "%s",$1; }'`; \
     EXPECTED_SIG=`curl -s https://composer.github.io/installer.sig | tr -d "\n"`; \
-    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] && \
+    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     apk del build-deps; \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -21,12 +21,12 @@ RUN \
     #  - Temporarily install perl-digest-hmac to provide shasum tools
     #  - Download composer-setup.php & check for file integrity
     #  - Run composer installation script
-    #  - Cleanup: remove installation script & perl-digest-hmac binaries
-    apk add --no-cache --virtual build-deps perl-digest-hmac && \
+    #  - Cleanup: remove installation script & core-utils binaries
+    apk add --no-cache --virtual build-deps coreutils && \
     curl https://getcomposer.org/installer -o composer-setup.php; \
-    ACTUAL_SIG=`shasum -a 384 composer-setup.php | awk '{ printf "%s",$1; }'`; \
+    ACTUAL_SIG=`sha384sum composer-setup.php | awk '{ printf "%s",$1; }'`; \
     EXPECTED_SIG=`curl -s https://composer.github.io/installer.sig | tr -d "\n"`; \
-    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] && \
+    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     apk del build-deps; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,12 @@ RUN \
     #  - Temporarily install perl-digest-hmac to provide shasum tools
     #  - Download composer-setup.php & check for file integrity
     #  - Run composer installation script
-    #  - Cleanup: remove installation script & perl-digest-hmac binaries
-    apk add --no-cache --virtual build-deps perl-digest-hmac && \
+    #  - Cleanup: remove installation script & core-utils binaries
+    apk add --no-cache --virtual build-deps coreutils && \
     curl https://getcomposer.org/installer -o composer-setup.php; \
-    ACTUAL_SIG=`shasum -a 384 composer-setup.php | awk '{ printf "%s",$1; }'`; \
+    ACTUAL_SIG=`sha384sum composer-setup.php | awk '{ printf "%s",$1; }'`; \
     EXPECTED_SIG=`curl -s https://composer.github.io/installer.sig | tr -d "\n"`; \
-    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] && \
+    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     apk del build-deps; \

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -21,12 +21,12 @@ RUN \
     #  - Temporarily install perl-digest-hmac to provide shasum tools
     #  - Download composer-setup.php & check for file integrity
     #  - Run composer installation script
-    #  - Cleanup: remove installation script & perl-digest-hmac binaries
-    apk add --no-cache --virtual build-deps perl-digest-hmac && \
+    #  - Cleanup: remove installation script & core-utils binaries
+    apk add --no-cache --virtual build-deps coreutils && \
     curl https://getcomposer.org/installer -o composer-setup.php; \
-    ACTUAL_SIG=`shasum -a 384 composer-setup.php | awk '{ printf "%s",$1; }'`; \
+    ACTUAL_SIG=`sha384sum composer-setup.php | awk '{ printf "%s",$1; }'`; \
     EXPECTED_SIG=`curl -s https://composer.github.io/installer.sig | tr -d "\n"`; \
-    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] && \
+    [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     apk del build-deps; \

--- a/update.sh
+++ b/update.sh
@@ -41,12 +41,12 @@ RUN \\
     #  - Temporarily install perl-digest-hmac to provide shasum tools
     #  - Download composer-setup.php & check for file integrity
     #  - Run composer installation script
-    #  - Cleanup: remove installation script & perl-digest-hmac binaries
-    apk add --no-cache --virtual build-deps perl-digest-hmac && \\
+    #  - Cleanup: remove installation script & core-utils binaries
+    apk add --no-cache --virtual build-deps coreutils && \\
     curl https://getcomposer.org/installer -o composer-setup.php; \\
-    ACTUAL_SIG=\`shasum -a 384 composer-setup.php | awk '{ printf "%s",\$1; }'\`; \\
+    ACTUAL_SIG=\`sha384sum composer-setup.php | awk '{ printf "%s",\$1; }'\`; \\
     EXPECTED_SIG=\`curl -s https://composer.github.io/installer.sig | tr -d "\n"\`; \\
-    [ "\$ACTUAL_SIG" = "\$EXPECTED_SIG" ] && \\
+    [ "\$ACTUAL_SIG" = "\$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \\
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \\
     rm composer-setup.php && \\
     apk del build-deps; \\


### PR DESCRIPTION
Fix composer install problems:
- Use new `sha384sum` binary for signature checks instead of `shasum` which does not exist anymore
- In case of signatures mismatch, just raise a warning message, but continue installing anyway