### PR TITLE
[composer] Fix write access problem on /.composer

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -29,6 +29,8 @@ RUN \
     [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
+    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+    mkdir /.composer && chmod 0777 /.composer; \
     apk del build-deps; \
     \
     # Purge APK cache

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -29,6 +29,8 @@ RUN \
     [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
+    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+    mkdir /.composer && chmod 0777 /.composer; \
     apk del build-deps; \
     \
     # Purge APK cache

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -29,6 +29,8 @@ RUN \
     [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
+    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+    mkdir /.composer && chmod 0777 /.composer; \
     apk del build-deps; \
     \
     # Purge APK cache

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -29,6 +29,8 @@ RUN \
     [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
+    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+    mkdir /.composer && chmod 0777 /.composer; \
     apk del build-deps; \
     \
     # Purge APK cache

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -29,6 +29,8 @@ RUN \
     [ "$ACTUAL_SIG" = "$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
+    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+    mkdir /.composer && chmod 0777 /.composer; \
     apk del build-deps; \
     \
     # Purge APK cache

--- a/update.sh
+++ b/update.sh
@@ -49,6 +49,8 @@ RUN \\
     [ "\$ACTUAL_SIG" = "\$EXPECTED_SIG" ] || echo "[composer] Error: signatures does not match!"; \\
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \\
     rm composer-setup.php && \\
+    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+    mkdir /.composer && chmod 0777 /.composer; \\
     apk del build-deps; \\
     \\
     # Purge APK cache


### PR DESCRIPTION
When configuring the container to be run by a user which Alpine does not recognize (by passing an UID/GID for example), the env variable `HOME` is set to `/`, hence `COMPOSER_HOME` will be `/.composer`.

Considering the following `docker-compose` file : 
```yaml
version: '3'
services:
    fpm:
        image: yannoff/php-fpm:7.1-fpm-alpine
        volumes:
            - "./:/var/www/html"
            - ".composer:/.composer"
        working_dir: /var/www/html
        user: "1000:1000"
```

Here the resulting id command output : 
```bash
bash-4.4$ id
uid=1000 gid=1000
bash-4.4$
```

..and the composer home config:

```bash
bash-4.4$ composer config home
/.composer
bash-4.4$ 
```