### PR TITLE
[build] Improve cleanup

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -55,7 +55,7 @@ RUN \
     make && make install && \
     libtool --finish /usr/local/lib; \
     cd .. && \
-    rm -rfv libiconv-1.14; \
+    rm -rf libiconv-1.14; \
     \
     # Use VIM for VI (instead of the poorly implemented BusyBox equivalent)
     rm /usr/bin/vi && ln -s /usr/bin/vim /usr/bin/vi && \
@@ -82,6 +82,6 @@ RUN \
     # - remove build dependencies
     # - purge APK repository cache
     # - remove PHP source tarballs
-    apk del build-deps .locale-build-deps .iconv-build-deps; \
-    rm -v /var/cache/apk/*; \
+    apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
+    rm -rf  /usr/local/include/*; \
     rm -rf /usr/src/*;

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -55,7 +55,7 @@ RUN \
     make && make install && \
     libtool --finish /usr/local/lib; \
     cd .. && \
-    rm -rfv libiconv-1.14; \
+    rm -rf libiconv-1.14; \
     \
     # Use VIM for VI (instead of the poorly implemented BusyBox equivalent)
     rm /usr/bin/vi && ln -s /usr/bin/vim /usr/bin/vi && \
@@ -82,6 +82,6 @@ RUN \
     # - remove build dependencies
     # - purge APK repository cache
     # - remove PHP source tarballs
-    apk del build-deps .locale-build-deps .iconv-build-deps; \
-    rm -v /var/cache/apk/*; \
+    apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
+    rm -rf  /usr/local/include/*; \
     rm -rf /usr/src/*;

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -55,7 +55,7 @@ RUN \
     make && make install && \
     libtool --finish /usr/local/lib; \
     cd .. && \
-    rm -rfv libiconv-1.14; \
+    rm -rf libiconv-1.14; \
     \
     # Use VIM for VI (instead of the poorly implemented BusyBox equivalent)
     rm /usr/bin/vi && ln -s /usr/bin/vim /usr/bin/vi && \
@@ -82,6 +82,6 @@ RUN \
     # - remove build dependencies
     # - purge APK repository cache
     # - remove PHP source tarballs
-    apk del build-deps .locale-build-deps .iconv-build-deps; \
-    rm -v /var/cache/apk/*; \
+    apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
+    rm -rf  /usr/local/include/*; \
     rm -rf /usr/src/*;

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -55,7 +55,7 @@ RUN \
     make && make install && \
     libtool --finish /usr/local/lib; \
     cd .. && \
-    rm -rfv libiconv-1.14; \
+    rm -rf libiconv-1.14; \
     \
     # Use VIM for VI (instead of the poorly implemented BusyBox equivalent)
     rm /usr/bin/vi && ln -s /usr/bin/vim /usr/bin/vi && \
@@ -82,6 +82,6 @@ RUN \
     # - remove build dependencies
     # - purge APK repository cache
     # - remove PHP source tarballs
-    apk del build-deps .locale-build-deps .iconv-build-deps; \
-    rm -v /var/cache/apk/*; \
+    apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
+    rm -rf  /usr/local/include/*; \
     rm -rf /usr/src/*;

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -55,7 +55,7 @@ RUN \
     make && make install && \
     libtool --finish /usr/local/lib; \
     cd .. && \
-    rm -rfv libiconv-1.14; \
+    rm -rf libiconv-1.14; \
     \
     # Use VIM for VI (instead of the poorly implemented BusyBox equivalent)
     rm /usr/bin/vi && ln -s /usr/bin/vim /usr/bin/vi && \
@@ -82,6 +82,6 @@ RUN \
     # - remove build dependencies
     # - purge APK repository cache
     # - remove PHP source tarballs
-    apk del build-deps .locale-build-deps .iconv-build-deps; \
-    rm -v /var/cache/apk/*; \
+    apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
+    rm -rf  /usr/local/include/*; \
     rm -rf /usr/src/*;

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -55,7 +55,7 @@ RUN \
     make && make install && \
     libtool --finish /usr/local/lib; \
     cd .. && \
-    rm -rfv libiconv-1.14; \
+    rm -rf libiconv-1.14; \
     \
     # Use VIM for VI (instead of the poorly implemented BusyBox equivalent)
     rm /usr/bin/vi && ln -s /usr/bin/vim /usr/bin/vi && \
@@ -82,6 +82,6 @@ RUN \
     # - remove build dependencies
     # - purge APK repository cache
     # - remove PHP source tarballs
-    apk del build-deps .locale-build-deps .iconv-build-deps; \
-    rm -v /var/cache/apk/*; \
+    apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
+    rm -rf  /usr/local/include/*; \
     rm -rf /usr/src/*;

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -55,7 +55,7 @@ RUN \
     make && make install && \
     libtool --finish /usr/local/lib; \
     cd .. && \
-    rm -rfv libiconv-1.14; \
+    rm -rf libiconv-1.14; \
     \
     # Use VIM for VI (instead of the poorly implemented BusyBox equivalent)
     rm /usr/bin/vi && ln -s /usr/bin/vim /usr/bin/vi && \
@@ -82,6 +82,6 @@ RUN \
     # - remove build dependencies
     # - purge APK repository cache
     # - remove PHP source tarballs
-    apk del build-deps .locale-build-deps .iconv-build-deps; \
-    rm -v /var/cache/apk/*; \
+    apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
+    rm -rf  /usr/local/include/*; \
     rm -rf /usr/src/*;

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -55,7 +55,7 @@ RUN \
     make && make install && \
     libtool --finish /usr/local/lib; \
     cd .. && \
-    rm -rfv libiconv-1.14; \
+    rm -rf libiconv-1.14; \
     \
     # Use VIM for VI (instead of the poorly implemented BusyBox equivalent)
     rm /usr/bin/vi && ln -s /usr/bin/vim /usr/bin/vi && \
@@ -82,6 +82,6 @@ RUN \
     # - remove build dependencies
     # - purge APK repository cache
     # - remove PHP source tarballs
-    apk del build-deps .locale-build-deps .iconv-build-deps; \
-    rm -v /var/cache/apk/*; \
+    apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
+    rm -rf  /usr/local/include/*; \
     rm -rf /usr/src/*;

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN \
     make && make install && \
     libtool --finish /usr/local/lib; \
     cd .. && \
-    rm -rfv libiconv-1.14; \
+    rm -rf libiconv-1.14; \
     \
     # Use VIM for VI (instead of the poorly implemented BusyBox equivalent)
     rm /usr/bin/vi && ln -s /usr/bin/vim /usr/bin/vi && \
@@ -82,6 +82,6 @@ RUN \
     # - remove build dependencies
     # - purge APK repository cache
     # - remove PHP source tarballs
-    apk del build-deps .locale-build-deps .iconv-build-deps; \
-    rm -v /var/cache/apk/*; \
+    apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
+    rm -rf  /usr/local/include/*; \
     rm -rf /usr/src/*;

--- a/update.sh
+++ b/update.sh
@@ -75,7 +75,7 @@ RUN \\
     make && make install && \\
     libtool --finish /usr/local/lib; \\
     cd .. && \\
-    rm -rfv libiconv-1.14; \\
+    rm -rf libiconv-1.14; \\
     \\
     # Use VIM for VI (instead of the poorly implemented BusyBox equivalent)
     rm /usr/bin/vi && ln -s /usr/bin/vim /usr/bin/vi && \\
@@ -102,8 +102,8 @@ RUN \\
     # - remove build dependencies
     # - purge APK repository cache
     # - remove PHP source tarballs
-    apk del build-deps .locale-build-deps .iconv-build-deps; \\
-    rm -v /var/cache/apk/*; \\
+    apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \\
+    rm -rf  /usr/local/include/*; \\
     rm -rf /usr/src/*;
 TEMPLATE
 


### PR DESCRIPTION
- Make `libiconv` cleanup silent
- Repair `apk del` invocation
- No more cleanup on `/var/cache/apk`
- Remove build deps include files