### PR TITLE
[build] Remove useless cleanup

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -97,12 +97,8 @@ RUN \
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
     \
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache ${installed}; \
-    \
-    rm -rf  /usr/local/include/*; \
-    rm -rf /usr/src/*;
+    apk add --no-cache ${installed};

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -97,12 +97,8 @@ RUN \
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
     \
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache ${installed}; \
-    \
-    rm -rf  /usr/local/include/*; \
-    rm -rf /usr/src/*;
+    apk add --no-cache ${installed};

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -97,12 +97,8 @@ RUN \
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
     \
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache ${installed}; \
-    \
-    rm -rf  /usr/local/include/*; \
-    rm -rf /usr/src/*;
+    apk add --no-cache ${installed};

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -97,12 +97,8 @@ RUN \
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
     \
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache ${installed}; \
-    \
-    rm -rf  /usr/local/include/*; \
-    rm -rf /usr/src/*;
+    apk add --no-cache ${installed};

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -97,12 +97,8 @@ RUN \
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
     \
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache ${installed}; \
-    \
-    rm -rf  /usr/local/include/*; \
-    rm -rf /usr/src/*;
+    apk add --no-cache ${installed};

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -97,12 +97,8 @@ RUN \
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
     \
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache ${installed}; \
-    \
-    rm -rf  /usr/local/include/*; \
-    rm -rf /usr/src/*;
+    apk add --no-cache ${installed};

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -97,12 +97,8 @@ RUN \
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
     \
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache ${installed}; \
-    \
-    rm -rf  /usr/local/include/*; \
-    rm -rf /usr/src/*;
+    apk add --no-cache ${installed};

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -97,12 +97,8 @@ RUN \
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
     \
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache ${installed}; \
-    \
-    rm -rf  /usr/local/include/*; \
-    rm -rf /usr/src/*;
+    apk add --no-cache ${installed};

--- a/8.1-rc/Dockerfile
+++ b/8.1-rc/Dockerfile
@@ -97,12 +97,8 @@ RUN \
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
     \
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache ${installed}; \
-    \
-    rm -rf  /usr/local/include/*; \
-    rm -rf /usr/src/*;
+    apk add --no-cache ${installed};

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,12 +97,8 @@ RUN \
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \
     \
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache ${installed}; \
-    \
-    rm -rf  /usr/local/include/*; \
-    rm -rf /usr/src/*;
+    apk add --no-cache ${installed};

--- a/update.sh
+++ b/update.sh
@@ -129,15 +129,11 @@ RUN \\
     # Cleanup:
     # - remove build dependencies
     # - restore installed packages (avoid collision with build deps)
-    # - remove C++ header files & PHP source tarball
     apk del --no-cache build-deps .locale-build-deps .iconv-build-deps; \\
     \\
     # Restore base installed packages, prevents accidental removal by build-deps cleanup
     # @see https://github.com/yannoff/docker-php-fpm/issues/28
-    apk add --no-cache \${installed}; \\
-    \\
-    rm -rf  /usr/local/include/*; \\
-    rm -rf /usr/src/*;
+    apk add --no-cache \${installed};
 TEMPLATE
 
 }


### PR DESCRIPTION
Remove useless (and problematic) sources files cleanup.

Since those files are already present in previous image
layers, removing them does not save any space.

On the other hand, they may be needed for further php
extension build.