### PR TITLE
Fix global `COMPOSER_HOME` setting

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -22,7 +22,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -77,8 +79,8 @@ RUN \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     \
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir $COMPOSER_HOME && chmod 0777 $COMPOSER_HOME; \
     \
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools https://github.com/yannoff/yamltools/releases/download/1.3.3/yamltools && chmod +x /usr/local/bin/yamltools && \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -22,7 +22,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -77,8 +79,8 @@ RUN \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     \
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir $COMPOSER_HOME && chmod 0777 $COMPOSER_HOME; \
     \
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools https://github.com/yannoff/yamltools/releases/latest/download/yamltools && chmod +x /usr/local/bin/yamltools && \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -22,7 +22,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -77,8 +79,8 @@ RUN \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     \
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir $COMPOSER_HOME && chmod 0777 $COMPOSER_HOME; \
     \
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools https://github.com/yannoff/yamltools/releases/latest/download/yamltools && chmod +x /usr/local/bin/yamltools && \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -22,7 +22,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -77,8 +79,8 @@ RUN \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     \
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir $COMPOSER_HOME && chmod 0777 $COMPOSER_HOME; \
     \
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools https://github.com/yannoff/yamltools/releases/latest/download/yamltools && chmod +x /usr/local/bin/yamltools && \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -22,7 +22,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -77,8 +79,8 @@ RUN \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     \
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir $COMPOSER_HOME && chmod 0777 $COMPOSER_HOME; \
     \
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools https://github.com/yannoff/yamltools/releases/latest/download/yamltools && chmod +x /usr/local/bin/yamltools && \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -22,7 +22,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -77,8 +79,8 @@ RUN \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     \
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir $COMPOSER_HOME && chmod 0777 $COMPOSER_HOME; \
     \
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools https://github.com/yannoff/yamltools/releases/latest/download/yamltools && chmod +x /usr/local/bin/yamltools && \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -22,7 +22,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -77,8 +79,8 @@ RUN \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     \
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir $COMPOSER_HOME && chmod 0777 $COMPOSER_HOME; \
     \
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools https://github.com/yannoff/yamltools/releases/latest/download/yamltools && chmod +x /usr/local/bin/yamltools && \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -22,7 +22,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -77,8 +79,8 @@ RUN \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     \
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir $COMPOSER_HOME && chmod 0777 $COMPOSER_HOME; \
     \
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools https://github.com/yannoff/yamltools/releases/latest/download/yamltools && chmod +x /usr/local/bin/yamltools && \

--- a/8.1-rc/Dockerfile
+++ b/8.1-rc/Dockerfile
@@ -22,7 +22,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -77,8 +79,8 @@ RUN \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     \
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir $COMPOSER_HOME && chmod 0777 $COMPOSER_HOME; \
     \
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools https://github.com/yannoff/yamltools/releases/latest/download/yamltools && chmod +x /usr/local/bin/yamltools && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -77,8 +79,8 @@ RUN \
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \
     rm composer-setup.php && \
     \
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir $COMPOSER_HOME && chmod 0777 $COMPOSER_HOME; \
     \
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools https://github.com/yannoff/yamltools/releases/latest/download/yamltools && chmod +x /usr/local/bin/yamltools && \

--- a/update.sh
+++ b/update.sh
@@ -54,7 +54,9 @@ ENV MUSL_LOCPATH /usr/local/share/i18n/locales/musl
 # @see https://github.com/docker-library/php/issues/240
 ENV LD_PRELOAD /usr/local/lib/preloadable_libiconv.so
 
-ENV PATH /.composer/vendor/bin:\$PATH
+# When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
+ENV COMPOSER_HOME /.composer
+ENV PATH \$COMPOSER_HOME/vendor/bin:\$PATH
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
@@ -109,8 +111,8 @@ RUN \\
     php composer-setup.php --filename=composer --install-dir=/usr/bin && \\
     rm composer-setup.php && \\
     \\
-    # When the container is run as an unknown user (e.g 1000), COMPOSER_HOME defaults to /.composer
-    mkdir /.composer && chmod 0777 /.composer; \\
+    # Ensure the COMPOSER_HOME directory is accessible to all users
+    mkdir \$COMPOSER_HOME && chmod 0777 \$COMPOSER_HOME; \\
     \\
     # Install yamltools standalone (ensure BC with any php version)
     curl -Lo /usr/local/bin/yamltools ${yamltools_url} && chmod +x /usr/local/bin/yamltools && \\


### PR DESCRIPTION
- Force `COMPOSER_HOME` to `/.composer`
- Ensure all users can access it

Fixes #42 