### PR TITLE
Revert frozen alpine version

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -5,9 +5,9 @@
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
-FROM php:5.5-fpm-alpine
+FROM php:5.5-fpm-alpine${ALPINE_VERSION}
 
 ARG TZ=UTC
 ARG PHP_EXTS="pdo_mysql pdo_pgsql intl opcache bcmath"

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -5,9 +5,9 @@
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
-FROM php:5.6-fpm-alpine
+FROM php:5.6-fpm-alpine${ALPINE_VERSION}
 
 ARG TZ=UTC
 ARG PHP_EXTS="pdo_mysql pdo_pgsql intl opcache bcmath"

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -5,9 +5,9 @@
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
-FROM php:7.0-fpm-alpine
+FROM php:7.0-fpm-alpine${ALPINE_VERSION}
 
 ARG TZ=UTC
 ARG PHP_EXTS="pdo_mysql pdo_pgsql intl opcache bcmath"

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -5,9 +5,9 @@
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
-FROM php:7.1-fpm-alpine
+FROM php:7.1-fpm-alpine${ALPINE_VERSION}
 
 ARG TZ=UTC
 ARG PHP_EXTS="pdo_mysql pdo_pgsql intl opcache bcmath"

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -5,9 +5,9 @@
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
-FROM php:7.2-fpm-alpine
+FROM php:7.2-fpm-alpine${ALPINE_VERSION}
 
 ARG TZ=UTC
 ARG PHP_EXTS="pdo_mysql pdo_pgsql intl opcache bcmath"

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -5,7 +5,7 @@
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
 FROM php:7.3-fpm-alpine${ALPINE_VERSION}
 

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -5,7 +5,7 @@
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
 FROM php:7.4-fpm-alpine${ALPINE_VERSION}
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -5,7 +5,7 @@
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
 FROM php:8.0-fpm-alpine${ALPINE_VERSION}
 

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -5,7 +5,7 @@
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
 FROM php:8.1-fpm-alpine${ALPINE_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
 FROM php:8.1-fpm-alpine${ALPINE_VERSION}
 

--- a/update.sh
+++ b/update.sh
@@ -17,17 +17,8 @@ generate_dockerfile(){
         yamltools_url=https://github.com/yannoff/yamltools/releases/latest/download/yamltools
     fi
 
-    case ${version} in
-        5.5|5.6|7.0|7.1|7.2)
-            image="${version}-fpm-alpine"
-            ;;
-        latest)
-            image="fpm-alpine\${ALPINE_VERSION}"
-            ;;
-        *)
-            image="${version}-fpm-alpine\${ALPINE_VERSION}"
-            ;;
-    esac
+    image="${version}-fpm-alpine"
+
     dockerfile=./${version}/Dockerfile
     cat > ${dockerfile} <<TEMPLATE
 #
@@ -37,9 +28,9 @@ generate_dockerfile(){
 # @author  Yannoff <https://github.com/yannoff>
 # @license MIT
 #
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION
 
-FROM php:${image}
+FROM php:${image}\${ALPINE_VERSION}
 
 ARG TZ=UTC
 ARG PHP_EXTS="pdo_mysql pdo_pgsql intl opcache bcmath"


### PR DESCRIPTION
Reverts #34 .

Since upgrading `docker-engine` is a reasonable workaround, the temporary fix introduced in #34 isn't necessary anymore.