### PR TITLE
[bugfix] `5.5`: Add missing `cmake` build dep

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN \
-    BUILD_DEPS="autoconf coreutils gcc libc-dev make patch"; \
+    BUILD_DEPS="autoconf cmake coreutils gcc libc-dev make patch"; \
     \
     echo -e "\033[01m******************************* Build arguments ******************************\033[00m"; \
     echo -e "\033[01mTZ:\033[01;33m ${TZ}\033[00m"; \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN \
-    BUILD_DEPS="autoconf coreutils gcc libc-dev make patch"; \
+    BUILD_DEPS="autoconf cmake coreutils gcc libc-dev make patch"; \
     \
     echo -e "\033[01m******************************* Build arguments ******************************\033[00m"; \
     echo -e "\033[01mTZ:\033[01;33m ${TZ}\033[00m"; \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN \
-    BUILD_DEPS="autoconf coreutils gcc libc-dev make patch"; \
+    BUILD_DEPS="autoconf cmake coreutils gcc libc-dev make patch"; \
     \
     echo -e "\033[01m******************************* Build arguments ******************************\033[00m"; \
     echo -e "\033[01mTZ:\033[01;33m ${TZ}\033[00m"; \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN \
-    BUILD_DEPS="autoconf coreutils gcc libc-dev make patch"; \
+    BUILD_DEPS="autoconf cmake coreutils gcc libc-dev make patch"; \
     \
     echo -e "\033[01m******************************* Build arguments ******************************\033[00m"; \
     echo -e "\033[01mTZ:\033[01;33m ${TZ}\033[00m"; \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN \
-    BUILD_DEPS="autoconf coreutils gcc libc-dev make patch"; \
+    BUILD_DEPS="autoconf cmake coreutils gcc libc-dev make patch"; \
     \
     echo -e "\033[01m******************************* Build arguments ******************************\033[00m"; \
     echo -e "\033[01mTZ:\033[01;33m ${TZ}\033[00m"; \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN \
-    BUILD_DEPS="autoconf coreutils gcc libc-dev make patch"; \
+    BUILD_DEPS="autoconf cmake coreutils gcc libc-dev make patch"; \
     \
     echo -e "\033[01m******************************* Build arguments ******************************\033[00m"; \
     echo -e "\033[01mTZ:\033[01;33m ${TZ}\033[00m"; \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN \
-    BUILD_DEPS="autoconf coreutils gcc libc-dev make patch"; \
+    BUILD_DEPS="autoconf cmake coreutils gcc libc-dev make patch"; \
     \
     echo -e "\033[01m******************************* Build arguments ******************************\033[00m"; \
     echo -e "\033[01mTZ:\033[01;33m ${TZ}\033[00m"; \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN \
-    BUILD_DEPS="autoconf coreutils gcc libc-dev make patch"; \
+    BUILD_DEPS="autoconf cmake coreutils gcc libc-dev make patch"; \
     \
     echo -e "\033[01m******************************* Build arguments ******************************\033[00m"; \
     echo -e "\033[01mTZ:\033[01;33m ${TZ}\033[00m"; \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN \
-    BUILD_DEPS="autoconf coreutils gcc libc-dev make patch"; \
+    BUILD_DEPS="autoconf cmake coreutils gcc libc-dev make patch"; \
     \
     echo -e "\033[01m******************************* Build arguments ******************************\033[00m"; \
     echo -e "\033[01mTZ:\033[01;33m ${TZ}\033[00m"; \

--- a/update.sh
+++ b/update.sh
@@ -55,7 +55,7 @@ ENV PATH \$COMPOSER_HOME/vendor/bin:\$PATH
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN \\
-    BUILD_DEPS="autoconf coreutils gcc libc-dev make patch"; \\
+    BUILD_DEPS="autoconf cmake coreutils gcc libc-dev make patch"; \\
     \\
     echo -e "\\033[01m******************************* Build arguments ******************************\\033[00m"; \\
     echo -e "\\033[01mTZ:\\033[01;33m \${TZ}\\033[00m"; \\


### PR DESCRIPTION
- Force `cmake` install as build dep